### PR TITLE
Build a static framework

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage.json" ~> 4.8.0
-github "mparticle/mparticle-apple-sdk" ~> 7.4.0
+github "mparticle/mparticle-apple-sdk" ~> 7.5.0

--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-AppsFlyer"
-    s.version          = "7.4.2"
+    s.version          = "7.5.0"
     s.summary          = "AppsFlyer integration for mParticle"
 
     s.description      = <<-DESC
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-AppsFlyer/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.4.0'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.5.0'
     s.ios.dependency 'AppsFlyerFramework', '~> 4.8'
     s.ios.pod_target_xcconfig = {
         'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/AppsFlyerFramework/**',

--- a/mParticle-AppsFlyer.podspec
+++ b/mParticle-AppsFlyer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-AppsFlyer"
-    s.version          = "7.5.0"
+    s.version          = "7.5.1"
     s.summary          = "AppsFlyer integration for mParticle"
 
     s.description      = <<-DESC

--- a/mParticle-AppsFlyer.xcodeproj/project.pbxproj
+++ b/mParticle-AppsFlyer.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-AppsFlyer";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -450,6 +451,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-AppsFlyer";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -473,6 +475,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-AppsFlyer";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Change Mach-o type to static library.
Updates mparticle-apple-sdk dependency to `~>7.5.0`. It shouldn't have any impact. Walmart.app links forked mparticle-apple-sdk which is already at v7.5.1.